### PR TITLE
Fix writing empty values in cache

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 commit = True
 tag = True
 files = setup.py omnipath/__init__.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 -r ../requirements.txt
-sphinx>=3.3.0
+sphinx>=4
 sphinx-autodoc-annotation
 sphinx-autodoc-typehints>=1.10.3
 sphinx-paramlinks

--- a/omnipath/__init__.py
+++ b/omnipath/__init__.py
@@ -7,7 +7,7 @@ import omnipath.interactions as interactions
 
 __author__ = ", ".join(["Michal Klein", "Dénes Türei"])
 __maintainer__ = ", ".join(["Michal Klein", "Dénes Türei"])
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 __email__ = "turei.denes@gmail.com"
 
 try:

--- a/omnipath/_core/cache/_cache.py
+++ b/omnipath/_core/cache/_cache.py
@@ -5,9 +5,19 @@ from pathlib import Path
 import os
 import pickle
 
+import pandas as pd
+
+
+def _is_empty(data: Optional[pd.DataFrame]) -> bool:
+    return data is None or (isinstance(data, pd.DataFrame) and not len(data))
+
 
 class Cache(ABC):
-    """Abstract class which defines the caching interface."""
+    """
+    Abstract class which defines the caching interface.
+
+    Empty values (`None` or an empty :class:`pandas.DataFrame`) will not be saved in the cache.
+    """
 
     @abstractmethod
     def __getitem__(self, key: str) -> Optional[Any]:
@@ -67,7 +77,9 @@ class FileCache(Cache):
 
         return (self._cache_dir / key).is_file()
 
-    def __setitem__(self, key: str, value: Any):
+    def __setitem__(self, key: str, value: Any) -> None:
+        if _is_empty(value):
+            return
         self._cache_dir.mkdir(parents=True, exist_ok=True)
 
         fname = str(key)
@@ -115,6 +127,11 @@ class MemoryCache(dict, Cache):
     def path(self) -> None:
         """Return `None`."""
         return None
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if _is_empty(value):
+            return
+        return super().__setitem__(key, value)
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__}[size={len(self)}]>"

--- a/omnipath/_core/cache/_cache.py
+++ b/omnipath/_core/cache/_cache.py
@@ -124,9 +124,9 @@ class MemoryCache(dict, Cache):
     """Cache which persists the data into the memory."""
 
     @property
-    def path(self) -> None:
-        """Return `None`."""
-        return None
+    def path(self) -> Optional[str]:
+        """Return `'memory'`."""
+        return "memory"
 
     def __setitem__(self, key: str, value: Any) -> None:
         if _is_empty(value):
@@ -145,6 +145,21 @@ class MemoryCache(dict, Cache):
     def copy(self) -> "MemoryCache":
         """Return self."""
         return self
+
+
+class NoopCache(MemoryCache):
+    """Cache which doesn't save anything."""
+
+    @property
+    def path(self) -> Optional[str]:
+        """Return `None`."""
+        return None
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        pass
+
+    def __str__(self):
+        return f"<{self.__class__.__name__}>"
 
 
 def clear_cache() -> None:

--- a/omnipath/constants/_pkg_constants.py
+++ b/omnipath/constants/_pkg_constants.py
@@ -36,7 +36,6 @@ class DEFAULT_OPTIONS:
     timeout: int = 600
     chunk_size: int = 8196
     cache_dir: Path = Path.home() / ".cache" / "omnipathdb"
-    mem_cache = None
     progress_bar: bool = True
     # for testing purposes
     autoload: bool = environ.get("OMNIPATH_AUTOLOAD", "") == ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,6 @@
 requires = ['setuptools', 'setuptools_scm', 'wheel']
 build-backend = 'setuptools.build_meta'
 
-[dev-dependencies]
-black = { version = "^19.10b0", python = "^3.6" }
-pytest = { version = "^5.3", python = "^3.6" }
-
 [tool.black]
 line-length = 88
 target-version = ['py38']
@@ -38,7 +34,7 @@ multi_line_output = 3
 include_trailing_comma = true
 use_parentheses = true
 known_num="numpy,pandas"
-sections = "FUTURE,STDLIB,THIRDPARTY,NUM,,FIRSTPARTY,LOCALFOLDER"
+sections = "FUTURE,STDLIB,THIRDPARTY,NUM,FIRSTPARTY,LOCALFOLDER"
 no_lines_before="LOCALFOLDER"
 balanced_wrapping = true
 force_grid_wrap = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ docrep>=0.3.1
 enum_tools>=0.6.1
 inflect>=4.1.0
 packaging
-pandas>=1.1.4
+pandas>=1.2.0
 requests>=2.24.0
 tqdm>=4.51.0
 typing_extensions>=3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
     __author__ = "Michal Klein, Dénes Türei"
     __maintainer__ = "Michal Klein, Dénes Türei"
     __email__ = "turei.denes@gmail.com"
-    __version__ = "1.0.3"
+    __version__ = "1.0.4"
 
 
 setup(
@@ -167,7 +167,6 @@ setup(
     zip_safe=False,
     python_requires=">=3.7",
     include_package_data=False,
-    # dependency_links = deplinks
     install_requires=list(
         map(
             str.strip,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="function")
 def options() -> "Options":
     opt = Options.from_config()
-    opt.cache = None
+    opt.cache = "memory"
     opt.progress_bar = False
     return opt
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,10 @@
 from copy import copy, deepcopy
+from typing import Optional
 from pathlib import Path
 
 import pytest
+
+import pandas as pd
 
 from omnipath import options, clear_cache
 from omnipath._core.cache._cache import FileCache, MemoryCache
@@ -52,6 +55,15 @@ class TestMemoryCache:
 
         assert len(mc) == 0
 
+    @pytest.mark.parametrize("val", [None, pd.DataFrame()])
+    def test_add_empty_value(self, val: Optional[pd.DataFrame]):
+        mc = MemoryCache()
+
+        mc["foo"] = val
+
+        assert "foo" not in mc
+        assert len(mc) == 0
+
 
 class TestPickleCache:
     def test_invalid_path(self):
@@ -97,3 +109,12 @@ class TestPickleCache:
 
         assert len(fc) == 0
         assert not Path(tmpdir).exists()
+
+    @pytest.mark.parametrize("val", [None, pd.DataFrame()])
+    def test_add_empty_value(self, tmpdir, val: Optional[pd.DataFrame]):
+        fc = FileCache(Path(tmpdir))
+
+        fc["foo"] = val
+
+        assert "foo" not in fc
+        assert len(fc) == 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,7 +7,7 @@ import pytest
 import pandas as pd
 
 from omnipath import options, clear_cache
-from omnipath._core.cache._cache import FileCache, MemoryCache
+from omnipath._core.cache._cache import FileCache, NoopCache, MemoryCache
 
 
 def test_clear_cache_high_lvl(cache_backup):
@@ -29,7 +29,7 @@ class TestMemoryCache:
 
     def test_path_is_None(self):
         mc = MemoryCache()
-        assert mc.path is None
+        assert mc.path == "memory"
 
     def test_copy_does_nothing(self):
         mc = MemoryCache()
@@ -118,3 +118,13 @@ class TestPickleCache:
 
         assert "foo" not in fc
         assert len(fc) == 0
+
+
+class TestNoopCache:
+    def test_add_value(self):
+        nc = NoopCache()
+        nc["foo"] = 42
+
+        assert nc.path is None
+        assert "foo" not in nc
+        assert len(nc) == 0

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -156,13 +156,15 @@ class TestInteractions:
         requests_mock.register_uri(
             "GET",
             f"{url}?datasets={datasets}&fields=curation_effort%2Creferences%2Csources%2Ctype&"
-            f"format=tsv&organisms={organisms.code}",
+            f"format=json&organisms={organisms.code}",
             content=interaction_resources,
         )
 
-        _ = AllInteractions.get(organism=organisms, format="tsv")
-        _ = AllInteractions.get(organisms=organisms.value, format="tsv")
+        x = AllInteractions.get(organism=organisms, format="json")
+        y = AllInteractions.get(organisms=organisms.value, format="json")
+
         assert requests_mock.called_once
+        pd.testing.assert_frame_equal(x, y)
 
     def test_dorothea_params(self):
         params = Dorothea.params()


### PR DESCRIPTION

No longer save `None` or empty DataFrames into cache + enable bypassing cache altogether. Current behavior:
```python3
import omnipath as op
op.options.cache = None  # bypass cache (previously would use the memory cache)
op.options.cache = "memory"  # save into memory (previously would save into `memory` directory)
op.options.cache = "foo"  # save files into `foo` directory
```
closes #7 