### PR TITLE
Add "small_molecule" as valid interaction dataset

### DIFF
--- a/omnipath/constants/_constants.py
+++ b/omnipath/constants/_constants.py
@@ -91,6 +91,7 @@ class InteractionDataset(PrettyEnumMixin):
     MIRNA_TARGET = "mirnatarget"
     OMNIPATH = "omnipath"
     PATHWAY_EXTRA = "pathwayextra"
+    SMALL_MOLECULE = "small_molecule"
     TF_MIRNA = "tf_mirna"
     TF_REGULONS = "tfregulons"
     TF_TARGET = "tf_target"


### PR DESCRIPTION
This seems to be a new change that's currently missing in the Python implementation. As a result, retrieving interaction resources fails with: ```ValueError: Invalid value `small_molecule` for `InteractionDataset`.``` This fixes the issue, but I am unaware if additional changes are needed.