### PR TITLE
Inherit request settings to avoid certificate issues

### DIFF
--- a/omnipath/_core/downloader/_downloader.py
+++ b/omnipath/_core/downloader/_downloader.py
@@ -173,10 +173,12 @@ class Downloader:
             File-like object containing the data. Usually a json- or csv-like data is present inside.
         """
         logging.info(f"Downloading data from `{req.url}`")
-
+        settings = self._session.merge_environment_settings(
+            req.url, {}, None, None, None
+        )
         handle = BytesIO()
         with self._session.send(
-            req, stream=True, timeout=self._options.timeout
+            req, stream=True, timeout=self._options.timeout, **settings
         ) as resp:
             resp.raise_for_status()
             total = resp.headers.get("content-length", None)

--- a/omnipath/_core/downloader/_downloader.py
+++ b/omnipath/_core/downloader/_downloader.py
@@ -176,9 +176,11 @@ class Downloader:
         settings = self._session.merge_environment_settings(
             req.url, {}, None, None, None
         )
+        settings['stream'] = True
+        settings['timeout'] = self._options.timeout
         handle = BytesIO()
         with self._session.send(
-            req, stream=True, timeout=self._options.timeout, **settings
+            req, **settings
         ) as resp:
             resp.raise_for_status()
             total = resp.headers.get("content-length", None)


### PR DESCRIPTION
Lets the `requests` session inherit settings from requests in order to respect system-wide configuration of certificate policies.

Unless there is a strict reason for neglecting globally set security options on requests, consider inheriting certificate settings from requests during `download`. If this is not possible, it would be great to optionally enable it using either an argument or environment variable.

Otherwise, maybe there is another way of allowing the request to be done using globally available settings and I just missed it?